### PR TITLE
Update service startup command to support multiple WSL instances

### DIFF
--- a/wsl-vpnkit.service
+++ b/wsl-vpnkit.service
@@ -9,7 +9,8 @@ ret=0
 
 start() {
         # using `wsl.exe` allows the daemon to keep running in the background even when you close your terminal
-        /mnt/c/WINDOWS/system32/wsl.exe --user $(whoami) -- $cmd --oknodo --background --start -- -c "exec $WSLVPNKIT_PATH >> $LOG_PATH 2>&1"
+        DISTRO_NAME=$(basename $(wslpath -m /))
+        /mnt/c/WINDOWS/system32/wsl.exe --user $(whoami) --distribution $DISTRO_NAME -- $cmd --oknodo --background --start -- -c "exec $WSLVPNKIT_PATH >> $LOG_PATH 2>&1"
         ret=$?
 }
 


### PR DESCRIPTION
I had an issue where wsl-vpnkit wasn't working as a service when there were multiple WSL distributions installed - to be more precise, I was unable to set-up wsl-vpnkit as a service on the WSL distribution that wasn't a default one. When the wsl-vpnkit was run normally (i.e. not as a service), then everything was working fine.
After further investigation I've discovered that within *start* function of *wsl-vpnkit.service* file there is command invocation via Windows' *wsl.exe* utility, but as there isn't explicitly defined distribution to use (with *-d* or *--distribution* option), the command was executed on the default distribution (and in my case, that wasn't the one where I was trying to set wsl-vpnkit).
By explicitly providing distribution name as a command line argument on invocation of *wsl.exe* program, I've no longer had any issues.
It's also worth noting that usually there is available environment variable in all WSL distributions with a name *WSL_DISTRO_NAME* that contains the name of currently running distribution, but since this service script is run as a service (which causes that environment variables from current user session aren't passed to the session instantiated by the service), that handy variable cannot be used, so the distribution name is derived from Windows path of current WSL's root directory.